### PR TITLE
Snapshot proof commands

### DIFF
--- a/docs/addresses.rst
+++ b/docs/addresses.rst
@@ -17,16 +17,10 @@ any other financial service.
         These performance issues will be fixed in a future version of the library;
         please bear with us!
 
-        In the meantime, if you are using Python 3, you can install a C extension
+        In the meantime, you can install a C extension
         that boosts PyOTA's performance significantly (speedups of 60x are common!).
 
         To install the extension, run ``pip install pyota[ccurl]``.
-
-        **Important:** The extension is not yet compatible with Python 2.
-
-        If you are familiar with Python 2's C API, we'd love to hear from you!
-        Check the `GitHub issue <https://github.com/todofixthis/pyota-ccurl/issues/4>`_
-        for more information.
 
 PyOTA provides two methods for generating addresses:
 
@@ -60,7 +54,9 @@ method, using the following parameters:
    (defaults to 1).
 -  If ``None``, the API will generate addresses until it finds one that
    has not been used (has no transactions associated with it on the
-   Tangle). It will then return the unused address and discard the rest.
+   Tangle, has no balance and was not spent from). This makes the command
+   safe to use even after a snapshot has been taken. It will then return the
+   unused address and discard the rest.
 -  ``security_level: int``: Determines the security level of the
    generated addresses. See `Security Levels <#security-levels>`__
    below.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,8 +89,10 @@ Parameters
    parameter behaves like the ``stop`` attribute in a ``slice`` object;
    the stop index is *not* included in the result.
 
--  If ``None`` (default), then this method will check every address
-   until it finds one without any transfers.
+-  If ``None`` (default), then this method will not stop until it finds
+   an unused address. This is one without any transactions, that has no
+   balance and that was not spent from. Note that a snapshot, which removes
+   transactions, can cause this API call to stop earlier.
 
 -  ``inclusion_states: bool`` Whether to also fetch the inclusion states
    of the transfers. This requires an additional API call to the node,
@@ -145,7 +147,9 @@ Parameters
 -  Note that this parameter behaves like the ``stop`` attribute in a
    ``slice`` object; the stop index is *not* included in the result.
 -  If ``None`` (default), then this method will not stop until it finds
-   an unused address.
+   an unused address. This is one without any transactions, that has no
+   balance and that was not spent from. Note that a snapshot, which removes
+   transactions, can cause this API call to stop earlier.
 -  ``threshold: Optional[int]``: If set, determines the minimum
    threshold for a successful result:
 -  As soon as this threshold is reached, iteration will stop.
@@ -199,11 +203,13 @@ Generates one or more new addresses from the seed.
 Parameters
 ~~~~~~~~~~
 
--  ``index: int``: Specify the index of the new address (must be >= 1).
+-  ``index: int``: Specify the index of the new address (must be >= 0).
 -  ``count: Optional[int]``: Number of addresses to generate (must be >=
    1).
 -  If ``None``, this method will scan the Tangle to find the next
-   available unused address and return that.
+   available unused address and return that. This is one without any
+   transactions, that has no balance and that was not spent from. This makes
+   the command safe to use even after a snapshot has been taken.
 -  ``security_level: int``: Number of iterations to use when generating
    new addresses. Lower values generate addresses faster, higher values
    result in more secure signatures in transactions.
@@ -228,8 +234,10 @@ Parameters
 -  ``stop: Optional[int]``: Stop before this index.
 -  Note that this parameter behaves like the ``stop`` attribute in a
    ``slice`` object; the stop index is *not* included in the result.
--  If ``None`` (default), then this method will check every address
-   until it finds one without any transfers.
+-  If ``None`` (default), then this method will not stop until it finds
+   an unused address. This is one without any transactions, that has no
+   balance and that was not spent from. Note that a snapshot, which removes
+   transactions, can cause this API call to stop earlier.
 
 Return
 ~~~~~~

--- a/iota/api.py
+++ b/iota/api.py
@@ -830,8 +830,7 @@ class Iota(StrictIota):
         Generates one or more new addresses from the seed.
 
         :param index:
-            The key index of the first new address to generate (must be
-            >= 1).
+            The key index of the first new address to generate (must be >= 0).
 
         :param count:
             Number of addresses to generate (must be >= 1).
@@ -841,8 +840,9 @@ class Iota(StrictIota):
                 inside a loop.
 
             If ``None``, this method will progressively generate
-            addresses and scan the Tangle until it finds one that has no
-            transactions referencing it.
+            addresses and scan the Tangle until it finds one that is unused.
+            This is if no transactions are referencing it and it has no balance
+            and it was not spent from before.
 
         :param security_level:
             Number of iterations to use when generating new addresses.

--- a/iota/commands/extended/get_account_data.py
+++ b/iota/commands/extended/get_account_data.py
@@ -59,7 +59,7 @@ class GetAccountDataCommand(FilterCommand):
             my_hashes = ft_command(addresses=my_addresses).get('hashes') or []
 
         account_balance = 0
-        if my_hashes:
+        if my_addresses:
             # Load balances for the addresses that we generated.
             gb_response = (
                 GetBalancesCommand(self.adapter)(addresses=my_addresses)

--- a/iota/commands/extended/get_new_addresses.py
+++ b/iota/commands/extended/get_new_addresses.py
@@ -9,6 +9,9 @@ import filters as f
 from iota import Address
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.find_transactions import FindTransactionsCommand
+from iota.commands.core.get_balances import GetBalancesCommand
+from iota.commands.core.were_addresses_spent_from import \
+    WereAddressesSpentFromCommand
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
 from iota.filters import SecurityLevel, Trytes
@@ -58,17 +61,29 @@ class GetNewAddressesCommand(FilterCommand):
         generator = AddressGenerator(seed, security_level, checksum)
 
         if count is None:
-            # Connect to Tangle and find the first address without any
-            # transactions.
+            # Connect to Tangle and find the first unused address.
             for addy in generator.create_iterator(start=index):
-                # We use addy.address here because FindTransactions does
+                # We use addy.address here because the commands do
                 # not work on an address with a checksum
+                response = WereAddressesSpentFromCommand(self.adapter)(
+                    addresses=[addy.address],
+                )
+                if response['states'][0]:
+                    continue
+
+                response = GetBalancesCommand(self.adapter)(
+                    addresses=[addy.address],
+                )
+                if response['balances'][0] != 0:
+                    continue
+
                 response = FindTransactionsCommand(self.adapter)(
                     addresses=[addy.address],
                 )
+                if response.get('hashes'):
+                    continue
 
-                if not response.get('hashes'):
-                    return [addy]
+                return [addy]
 
         return generator.get_addresses(start=index, count=count)
 

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -435,3 +435,28 @@ class GetAccountDataCommandTestCase(TestCase):
         'bundles':    [],
       },
     )
+
+  def test_balance_is_found_for_address_without_transaction(self):
+    """
+    If an address has a balance but no transaction due to a snapshot the
+    balance should still be found and returned.
+    """
+    with mock.patch(
+        'iota.commands.extended.get_account_data.iter_used_addresses',
+        mock.Mock(return_value=[(self.addy1, [])]),
+    ):
+      self.adapter.seed_response('getBalances', {
+        'balances': [42],
+      })
+
+      response = self.command(seed=Seed.random())
+
+    self.assertDictEqual(
+      response,
+
+      {
+        'addresses':  [self.addy1],
+        'balance':    42,
+        'bundles':    [],
+      },
+    )

--- a/test/commands/extended/get_inputs_test.py
+++ b/test/commands/extended/get_inputs_test.py
@@ -590,12 +590,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     No ``stop`` provided, balance meets ``threshold``.
     """
-    self.adapter.seed_response('getBalances', {
-      'balances': [42, 29],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions``, ``getBalances`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -618,6 +615,18 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [0],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [42, 29],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -686,12 +695,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     No ``stop`` provided, ``threshold`` is 0.
     """
-    # Note that the first address has a zero balance.
-    self.adapter.seed_response('getBalances', {
-      'balances': [0, 1],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
+    # ``getInputs`` uses ``findTransactions``, ``getBalances`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
@@ -715,6 +721,19 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [0],
+    })
+
+    # Note that the first address has a zero balance.
+    self.adapter.seed_response('getBalances', {
+      'balances': [0, 1],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -750,12 +769,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     No ``stop`` provided, no ``threshold``.
     """
-    self.adapter.seed_response('getBalances', {
-      'balances': [42, 29],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions``, ``getBalances`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -778,6 +794,18 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [0],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [42, 29],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -818,12 +846,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     Using ``start`` to offset the key range.
     """
-    self.adapter.seed_response('getBalances', {
-      'balances': [86],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions``, ``getBalances`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -836,6 +861,18 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [0],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [86],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -926,11 +963,8 @@ class GetInputsCommandTestCase(TestCase):
     seed = Seed.random()
     address = AddressGenerator(seed, security_level=1).get_addresses(0)[0]
 
-    self.adapter.seed_response('getBalances', {
-      'balances': [86],
-    })
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions``, ``getBalances`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -942,6 +976,18 @@ class GetInputsCommandTestCase(TestCase):
     })
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [0],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [86],
     })
 
     response = GetInputsCommand(self.adapter)(

--- a/test/commands/extended/get_transfers_test.py
+++ b/test/commands/extended/get_transfers_test.py
@@ -372,13 +372,26 @@ class GetTransfersCommandTestCase(TestCase):
       },
     )
 
-    # The second address is unused.
+    # The second address is unused. It has no transactions, was not spent from
+    # and has no balance.
     self.adapter.seed_response(
       'findTransactions',
 
       {
         'duration': 1,
         'hashes':   [],
+      },
+    )
+    self.adapter.seed_response(
+      'wereAddressesSpentFrom',
+      {
+        'states': [False],
+      },
+    )
+    self.adapter.seed_response(
+      'getBalances',
+      {
+        'balances': [0],
       },
     )
 
@@ -461,6 +474,18 @@ class GetTransfersCommandTestCase(TestCase):
         'hashes':   [],
       },
     )
+    self.adapter.seed_response(
+      'wereAddressesSpentFrom',
+      {
+        'states': [False],
+      },
+    )
+    self.adapter.seed_response(
+      'getBalances',
+      {
+        'balances': [0],
+      },
+    )
 
     with mock.patch(
         'iota.crypto.addresses.AddressGenerator.create_iterator',
@@ -495,13 +520,26 @@ class GetTransfersCommandTestCase(TestCase):
       },
     )
 
-    # The second address is unused.
+    # The second address is unused. It has no transactions, was not spent from
+    # and has no balance.
     self.adapter.seed_response(
       'findTransactions',
 
       {
         'duration': 1,
         'hashes':   [],
+      },
+    )
+    self.adapter.seed_response(
+      'wereAddressesSpentFrom',
+      {
+        'states': [False],
+      },
+    )
+    self.adapter.seed_response(
+      'getBalances',
+      {
+        'balances': [0],
       },
     )
 

--- a/test/commands/extended/utils_test.py
+++ b/test/commands/extended/utils_test.py
@@ -1,0 +1,351 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from unittest import TestCase
+
+from iota.commands.extended.utils import iter_used_addresses
+
+from iota import MockAdapter
+from iota.crypto.types import Seed
+from test import mock
+
+
+class IterUsedAddressesTestCase(TestCase):
+    def setUp(self):
+        super(IterUsedAddressesTestCase, self).setUp()
+
+        self.adapter = MockAdapter()
+        self.seed = Seed(trytes='S' * 81)
+        self.address0 = 'A' * 81
+        self.address1 = 'B' * 81
+        self.address2 = 'C' * 81
+        self.address3 = 'D' * 81
+
+        # To speed up the tests, we will mock the address generator.
+        def address_generator(ag, start, step=1):
+            for addy in [self.address0, self.address1, self.address2,
+                         self.address3][start::step]:
+                yield addy
+        self.mock_address_generator = address_generator
+
+    def seed_unused_address(self):
+        self.adapter.seed_response('findTransactions', {
+            'hashes': [],
+        })
+        self.adapter.seed_response('wereAddressesSpentFrom', {
+            'states': [False],
+        })
+        self.adapter.seed_response('getBalances', {
+            'balances': [0],
+        })
+
+    def get_all_used_addresses(self, start=0):
+        return [address for address, _
+                in iter_used_addresses(self.adapter, self.seed, start)]
+
+    def test_fist_address_is_not_used(self):
+        """
+        The very fist address is not used. No address is returned.
+        """
+        # Address 0
+        self.seed_unused_address()
+
+        with mock.patch(
+                'iota.crypto.addresses.AddressGenerator.create_iterator',
+                self.mock_address_generator,
+        ):
+            self.assertEqual([], self.get_all_used_addresses())
+
+        self.assertListEqual(
+            self.adapter.requests,
+            [
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address0],
+                    'threshold': 100,
+                },
+            ]
+        )
+
+    def test_transactions_are_considered_used(self):
+        """
+        An address with a transaction is considered used.
+        """
+        # Address 0
+        self.adapter.seed_response('findTransactions', {
+            'hashes': ['T' * 81],
+        })
+
+        # Address 1
+        self.seed_unused_address()
+
+        with mock.patch(
+                'iota.crypto.addresses.AddressGenerator.create_iterator',
+                self.mock_address_generator,
+        ):
+            self.assertEqual([self.address0], self.get_all_used_addresses())
+
+        self.assertListEqual(
+            self.adapter.requests,
+            [
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address1],
+                    'threshold': 100,
+                },
+            ]
+        )
+
+    def test_spent_from_is_considered_used(self):
+        """
+        An address that was spent from is considered used.
+        """
+        # Address 0
+        self.adapter.seed_response('findTransactions', {
+            'hashes': [],
+        })
+        self.adapter.seed_response('wereAddressesSpentFrom', {
+            'states': [True],
+        })
+
+        # Address 1
+        self.seed_unused_address()
+
+        with mock.patch(
+                'iota.crypto.addresses.AddressGenerator.create_iterator',
+                self.mock_address_generator,
+        ):
+            self.assertEqual([self.address0], self.get_all_used_addresses())
+
+        self.assertListEqual(
+            self.adapter.requests,
+            [
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address1],
+                    'threshold': 100,
+                },
+            ]
+        )
+
+    def test_balance_is_considered_used(self):
+        """
+        An address that that has a balance is considered used
+        """
+        # Address 0
+        self.adapter.seed_response('findTransactions', {
+            'hashes': [],
+        })
+        self.adapter.seed_response('wereAddressesSpentFrom', {
+            'states': [False],
+        })
+        self.adapter.seed_response('getBalances', {
+            'balances': [42],
+        })
+
+        # Address 1
+        self.seed_unused_address()
+
+        with mock.patch(
+                'iota.crypto.addresses.AddressGenerator.create_iterator',
+                self.mock_address_generator,
+        ):
+            self.assertEqual([self.address0], self.get_all_used_addresses())
+
+        self.assertListEqual(
+            self.adapter.requests,
+            [
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address0],
+                    'threshold': 100,
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address1],
+                    'threshold': 100,
+                },
+            ]
+        )
+
+    def test_start_parameter_is_given(self):
+        """
+        The correct address is returned if a start parameter is given
+        """
+        # Address 1
+        self.adapter.seed_response('findTransactions', {
+            'hashes': ['T' * 81],
+        })
+
+        # Address 2
+        self.seed_unused_address()
+
+        with mock.patch(
+                'iota.crypto.addresses.AddressGenerator.create_iterator',
+                self.mock_address_generator,
+        ):
+            self.assertEqual([self.address1],
+                             self.get_all_used_addresses(start=1))
+
+        self.assertListEqual(
+            self.adapter.requests,
+            [
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address2],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address2],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address2],
+                    'threshold': 100,
+                },
+            ]
+        )
+
+    def test_multiple_addresses_return(self):
+        """
+        A larger test that combines multiple cases and more than one address
+        should be returned.
+        Address 0: Has a balance
+        Address 1: Was spent from
+        Address 2: Has a transaction
+        Address 3: Is not used. Should not be returned
+        """
+        # Address 0
+        self.adapter.seed_response('findTransactions', {
+            'hashes': [],
+        })
+        self.adapter.seed_response('wereAddressesSpentFrom', {
+            'states': [False],
+        })
+        self.adapter.seed_response('getBalances', {
+            'balances': [42],
+        })
+
+        # Address 1
+        self.adapter.seed_response('findTransactions', {
+            'hashes': [],
+        })
+        self.adapter.seed_response('wereAddressesSpentFrom', {
+            'states': [True],
+        })
+
+        # Address 2
+        self.adapter.seed_response('findTransactions', {
+            'hashes': ['T' * 81],
+        })
+
+        # Address 3
+        self.seed_unused_address()
+
+        with mock.patch(
+                'iota.crypto.addresses.AddressGenerator.create_iterator',
+                self.mock_address_generator,
+        ):
+            self.assertEqual([self.address0, self.address1, self.address2],
+                             self.get_all_used_addresses())
+
+        self.assertListEqual(
+            self.adapter.requests,
+            [
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address0],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address0],
+                    'threshold': 100,
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address1],
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address2],
+                },
+                {
+                    'command': 'findTransactions',
+                    'addresses': [self.address3],
+                },
+                {
+                    'command': 'wereAddressesSpentFrom',
+                    'addresses': [self.address3],
+                },
+                {
+                    'command': 'getBalances',
+                    'addresses': [self.address3],
+                    'threshold': 100,
+                },
+            ]
+        )


### PR DESCRIPTION
resolves #217, resolves #175, resolves #46 

This PR makes getNewAddresses, getInputs, getTransfers and getAccountData snapshot proof. It also follows the behaviour of the Javascript library more closely but it is not exactly the same. There is a difference in how these commands behave on addresses with balances and without transactions. I opened a ticket in the JavaScript GitHub repository where I documented the behaviour of the JavaScript library on such addresses (https://github.com/iotaledger/iota.js/issues/427). As I stated in this ticket I think that the behaviour of the JavaScript library is in these cases a bit strange and I think that my suggestion that I also implemented in this PR is more logical. There has been no response so far but maybe @lzpap  could help to coordinate how the commands should behave for addresses with balance and without transactions?