### PR TITLE
fixing TrytesCompatible so that its no longer generic. 

### DIFF
--- a/iota/types.py
+++ b/iota/types.py
@@ -3,7 +3,7 @@ from codecs import decode, encode
 from itertools import chain
 from math import ceil
 from random import SystemRandom
-from typing import Any, AnyStr, Generator, Iterable, Iterator, List, \
+from typing import Any, Generator, Iterable, Iterator, List, \
     MutableSequence, Optional, Type, TypeVar, Union, Dict
 from warnings import warn
 
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 # Custom types for type hints and docstrings.
-TrytesCompatible = Union[AnyStr, bytearray, 'TryteString']
+TrytesCompatible = Union[str, bytes, bytearray, 'TryteString']
 
 T = TypeVar('T', bound='TryteString')
 


### PR DESCRIPTION

# Description of change

Fixes an error found by using the Pylance LS in basic typechecking mode.
![image](https://user-images.githubusercontent.com/1946977/117411948-075b1000-aec9-11eb-8db9-160ea1c6069f.png)


I'm assuming the original code was meant to be  "str or bytes". Most the docstrings mention `Byte string or bytearray.`
Using a constrained TypeVar like AnyStr in a Union is usually a mistake.

TrytesCompatible = Union[AnyStr, bytearray, 'TryteString'] defines a generic type alias, which can be legitimate. To use it properly, you'd need to provide a type argument that is compatible with the AnyStr type variable.

TrytesCompatible[str] or TrytesCompatible[bytes] or TrytesCompatible[AnyStr] would all be allowed.




## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Ran all tests
`python setup.py test`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (`docs/` directory and/or `docstring`s in source code)
- [X] I have followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) Style Guide in my code.
- [X] New and existing unit tests pass locally with my changes
