### PR TITLE
#344 changes in 02_send_data.py

### DIFF
--- a/examples/tutorials/02_send_data.py
+++ b/examples/tutorials/02_send_data.py
@@ -2,13 +2,13 @@ from iota import Iota, TryteString, Address, Tag, ProposedTransaction
 from pprint import pprint
 
 # Declare an API object
-api = Iota('https://nodes.devnet.iota.org:443', devnet=True)
+api = Iota('https://nodes.devnet.iota.org:443')
 
 # Prepare custom data
 my_data = TryteString.from_unicode('Hello from the Tangle!')
 
 # Generate a random address that doesn't have to belong to anyone
-my_address = Address.random()
+my_address = Address.random(81)
 
 # Tag is optional here
 my_tag = Tag(b'MY9FIRST9TAG')
@@ -22,7 +22,7 @@ tx = ProposedTransaction(
 )
 
 # Send the transaction to the network
-response = api.send_transfer([tx])
+response = api.send_transfer([tx], min_weight_magnitude=9)
 
 pprint('Check your transaction on the Tangle!')
-pprint('https://utils.iota.org/transaction/%s/devnet' % response['bundle'][0].hash)
+pprint('https://explorer.iota.org/legacy-devnet/transaction/%s' % response['bundle'][0].hash)


### PR DESCRIPTION
# Description of change
Changes are:
1. Removed 'devnet' keyword in Iota(...) because not a known argument
2. Add length of 81 to random address generation, because call needs length passed as argument
3. Node expects 9 as min. weight magnitude, therefore added as argument to send_transfer call
4. changed URL to check transaction to https://explorer.iota.org/legacy-devnet/transaction/%s
Fixing # (344).

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

PyOTA Version: 2.1.0
Python Version: 3.8.8

Tested script locally, data is attached:
https://explorer.iota.org/legacy-devnet/transaction/RUXNMQXLCJ9FZNGZFFWYXZUISGAUQDFVWGOVEMUACGJWXQGEUZHFFWHKIRZLYVEIPLVEBEH9YOEBRZ999

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (`docs/` directory and/or `docstring`s in source code)
- [ ] I have followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) Style Guide in my code.
- [ ] New and existing unit tests pass locally with my changes
